### PR TITLE
Implicit dependency on matplotlib functions removed in 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    matplotlib >= 3.5.0
+    matplotlib >= 3.5.0, < 3.9
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Functions deprecated in 3.7 and removed in 3.9

https://matplotlib.org/3.8.4/api/cm_api.html#matplotlib.cm.get_cmap

https://matplotlib.org/stable/api/cm_api.html

To test

```
import matplotlib.cm
matplotlib.cm.get_cmap
```